### PR TITLE
Set up Next.js scaffold and merge driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* merge=ours

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # ParallarXiv
+
+This repository contains the base framework for a Next.js website that will visualize arXiv papers. The project is prepared for deployment to Vercel.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Building
+
+```bash
+npm run build
+npm start
+```
+
+## Vercel configuration
+
+1. **Project Settings**
+   - Connect this repository to Vercel.
+   - Set the **Framework Preset** to **Next.js**.
+   - The build command is `npm run build` and the output directory is `.next`.
+   - Set the install command to `npm install` (or leave blank for Vercel default).
+
+2. **Environment Variables**
+   - Add any variables needed for fetching from the arXiv API.
+
+3. **Deploy**
+   - Push to the `main` or a feature branch. Vercel automatically builds and deploys.
+   - Visit the deployed URL to verify you see the placeholder message.
+
+## Merge conflict resolution
+
+This repository uses a custom `ours` merge driver to automatically resolve conflicts in favor of the feature branch. The `.gitattributes` file configures this driver for all files. The Git configuration contains:
+
+```bash
+git config merge.ours.driver true
+```
+
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "parallarxiv",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,15 @@
+import Head from 'next/head'
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>ParallarXiv</title>
+      </Head>
+      <main>
+        <h1>ParallarXiv</h1>
+        <p>Deployment successful!</p>
+      </main>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- initialize Next.js layout with a placeholder index page
- configure build scripts in `package.json`
- add `.gitignore`
- document Vercel configuration and merge strategy in `README`
- set `.gitattributes` to use the `ours` merge driver

## Testing
- `npm run build` *(fails: `next` not found)*