### PR TITLE
Add fake paper generator API

### DIFF
--- a/lib/generatePapers.js
+++ b/lib/generatePapers.js
@@ -1,0 +1,41 @@
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function sample(arr) {
+  return arr[randomInt(0, arr.length - 1)];
+}
+
+export function generatePapers(count = 5000) {
+  const topics = Array.from({ length: 15 }, (_, i) => `Topic ${i + 1}`);
+  const papersByTopic = topics.map(() => []);
+  const papers = [];
+
+  for (let id = 1; id <= count; id++) {
+    const topicIndex = randomInt(0, topics.length - 1);
+    const paper = {
+      id,
+      name: `${id}`,
+      topic: topics[topicIndex],
+      citations: [],
+      citationCount: 0,
+    };
+    papersByTopic[topicIndex].push(paper);
+    papers.push(paper);
+  }
+
+  for (const paper of papers) {
+    const topicIndex = topics.indexOf(paper.topic);
+    const sameTopic = papersByTopic[topicIndex].filter(p => p.id !== paper.id);
+    const otherPapers = papers.filter(p => p.topic !== paper.topic);
+    const citationNum = randomInt(10, 20);
+    for (let i = 0; i < citationNum; i++) {
+      const fromSameDomain = Math.random() < 0.7;
+      const source = fromSameDomain && sameTopic.length > 0 ? sample(sameTopic) : sample(otherPapers);
+      paper.citations.push(source.id);
+    }
+    paper.citationCount = Math.round(citationNum * (Math.random() * 3 + 1));
+  }
+
+  return papers;
+}

--- a/pages/api/papers.js
+++ b/pages/api/papers.js
@@ -1,0 +1,8 @@
+import { generatePapers } from '../../lib/generatePapers';
+
+export default function handler(req, res) {
+  const { count } = req.query;
+  const num = parseInt(count, 10) || 5000;
+  const papers = generatePapers(num);
+  res.status(200).json(papers);
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,6 +9,7 @@ export default function Home() {
       <main>
         <h1>ParallarXiv</h1>
         <p>Deployment successful!</p>
+        <p>Visit <code>/api/papers</code> for generated paper data.</p>
       </main>
     </>
   )


### PR DESCRIPTION
## Summary
- generate artificial papers in a new library helper
- expose `/api/papers` API route that returns generated papers
- update homepage with pointer to the API

## Testing
- `npm test` *(fails: Missing script)*