### PR TITLE
Add hierarchical topic mapping to paper generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ npm run build
 npm start
 ```
 
+## Generated Paper API
+
+An API route at `/api/papers` returns synthetic paper data. Each response
+includes a `papers` array and a `topics` hierarchy describing subcategories.
+
 ## Vercel configuration
 
 1. **Project Settings**

--- a/lib/generatePapers.js
+++ b/lib/generatePapers.js
@@ -1,0 +1,90 @@
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function sample(arr) {
+  return arr[randomInt(0, arr.length - 1)];
+}
+
+export function generateTopicHierarchy() {
+  const topics = [];
+  topics.push({
+    name: 'Biophysics',
+    associatedWith: ['Biology', 'Physics'],
+    subcategories: [
+      { name: 'Optogenetics', subcategories: [] },
+      {
+        name: 'Neurobiophysics',
+        subcategories: [
+          { name: 'Membrane Ion Channel Properties', subcategories: [] },
+        ],
+      },
+    ],
+  });
+
+  for (let i = 2; i <= 15; i++) {
+    const subcategories = Array.from({ length: 3 }, (_, j) => ({
+      name: `Subtopic ${i}.${j + 1}`,
+      subcategories: [
+        { name: `Detail ${i}.${j + 1}.1`, subcategories: [] },
+        { name: `Detail ${i}.${j + 1}.2`, subcategories: [] },
+      ],
+    }));
+
+    topics.push({
+      name: `Topic ${i}`,
+      associatedWith: [],
+      subcategories,
+    });
+  }
+
+  return topics;
+}
+
+export function generatePapers(count = 5000) {
+  const topicHierarchy = generateTopicHierarchy();
+  const topics = topicHierarchy.map(t => t.name);
+  const papersByTopic = topics.map(() => []);
+  const papers = [];
+
+  for (let id = 1; id <= count; id++) {
+    const topicIndex = randomInt(0, topics.length - 1);
+    const topicNode = topicHierarchy[topicIndex];
+    let subCategory = null;
+    let subSubCategory = null;
+    if (topicNode.subcategories.length) {
+      const subCatNode = sample(topicNode.subcategories);
+      subCategory = subCatNode.name;
+      if (subCatNode.subcategories.length) {
+        subSubCategory = sample(subCatNode.subcategories).name;
+      }
+    }
+
+    const paper = {
+      id,
+      name: `${id}`,
+      topic: topicNode.name,
+      subCategory,
+      subSubCategory,
+      citations: [],
+      citationCount: 0,
+    };
+    papersByTopic[topicIndex].push(paper);
+    papers.push(paper);
+  }
+
+  for (const paper of papers) {
+    const topicIndex = topics.indexOf(paper.topic);
+    const sameTopic = papersByTopic[topicIndex].filter(p => p.id !== paper.id);
+    const otherPapers = papers.filter(p => p.topic !== paper.topic);
+    const citationNum = randomInt(10, 20);
+    for (let i = 0; i < citationNum; i++) {
+      const fromSameDomain = Math.random() < 0.7;
+      const source = fromSameDomain && sameTopic.length > 0 ? sample(sameTopic) : sample(otherPapers);
+      paper.citations.push(source.id);
+    }
+    paper.citationCount = Math.round(citationNum * (Math.random() * 3 + 1));
+  }
+
+  return { papers, topics: topicHierarchy };
+}

--- a/pages/api/papers.js
+++ b/pages/api/papers.js
@@ -1,0 +1,8 @@
+import { generatePapers } from '../../lib/generatePapers';
+
+export default function handler(req, res) {
+  const { count } = req.query;
+  const num = parseInt(count, 10) || 5000;
+  const data = generatePapers(num);
+  res.status(200).json(data);
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,6 +9,10 @@ export default function Home() {
       <main>
         <h1>ParallarXiv</h1>
         <p>Deployment successful!</p>
+        <p>
+          Visit <code>/api/papers</code> for generated paper data including a
+          topic hierarchy with subcategories.
+        </p>
       </main>
     </>
   )


### PR DESCRIPTION
## Summary
- add topic hierarchy generator to create subcategory relationships
- include topic info when generating papers
- update API to return paper data and topic mapping
- document the `/api/papers` endpoint

## Testing
- `npm test` *(fails: Missing script)*