### PR TITLE
Fix python path for Vercel build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
-  "buildCommand": "python generate_papers.py",
+  "buildCommand": "python3 generate_papers.py",
   "outputDirectory": "."
 }


### PR DESCRIPTION
## Summary
- use `python3` in `vercel.json` build command

## Testing
- `python -m unittest`