### PR TITLE
Start interactive content automatically

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,26 +8,12 @@
         overflow: hidden;
         font-family: sans-serif;
       }
-      #overlay {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        background: rgba(0, 0, 0, 0.6);
-        color: #fff;
-        cursor: pointer;
-        z-index: 1;
-      }
+      /* overlay removed */
     </style>
     <script src="https://unpkg.com/three@0.160.1/build/three.min.js"></script>
     <script src="https://unpkg.com/three@0.160.1/examples/js/controls/PointerLockControls.js"></script>
   </head>
   <body>
-    <div id="overlay">Click to start</div>
     <script>
       const scene = new THREE.Scene();
       scene.background = new THREE.Color(0x000000);
@@ -46,16 +32,8 @@
 
       const controls = new THREE.PointerLockControls(camera, renderer.domElement);
 
-      const overlay = document.getElementById('overlay');
-      overlay.addEventListener('click', () => {
-        controls.lock();
-      });
-      controls.addEventListener('lock', () => {
-        overlay.style.display = 'none';
-      });
-      controls.addEventListener('unlock', () => {
-        overlay.style.display = 'flex';
-      });
+      // automatically lock pointer on page load
+      controls.lock();
 
       const objects = []; // store balls
       const velocities = new Map();

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,27 +9,13 @@ export default function Home() {
       </Head>
       <Script src="https://unpkg.com/three@0.160.1/build/three.min.js" strategy="beforeInteractive" />
       <Script src="https://unpkg.com/three@0.160.1/examples/js/controls/PointerLockControls.js" strategy="beforeInteractive" />
-      <div id="overlay">Click to start</div>
       <style jsx global>{`
         body {
           margin: 0;
           overflow: hidden;
           font-family: sans-serif;
         }
-        #overlay {
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          background: rgba(0, 0, 0, 0.6);
-          color: #fff;
-          cursor: pointer;
-          z-index: 1;
-        }
+        /* overlay removed */
       `}</style>
       {/* Scene setup */}
       <Script id="main-script" strategy="lazyOnload">
@@ -46,16 +32,8 @@ export default function Home() {
 
           const controls = new THREE.PointerLockControls(camera, renderer.domElement);
 
-          const overlay = document.getElementById('overlay');
-          overlay.addEventListener('click', () => {
-            controls.lock();
-          });
-          controls.addEventListener('lock', () => {
-            overlay.style.display = 'none';
-          });
-          controls.addEventListener('unlock', () => {
-            overlay.style.display = 'flex';
-          });
+          // automatically lock pointer on page load
+          controls.lock();
 
           const objects = [];
           const velocities = new Map();


### PR DESCRIPTION
## Summary
- remove overlay in `index.html` and `pages/index.js`
- automatically lock the pointer on page load

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460234b45c83249d3fcad0f0cef439