### PR TITLE
Add pause toggle and menu sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,14 @@
   const fovInput = document.getElementById('menu-fov');
   const speedInput = document.getElementById('menu-speed');
 
-  toggleBtn.addEventListener('click', () => {
+  let paused = false;
+
+  function toggleMenu() {
     menu.classList.toggle('minimized');
-  });
+    paused = !menu.classList.contains('minimized');
+  }
+
+  toggleBtn.addEventListener('click', toggleMenu);
 
   function resize() {
     canvas.width = window.innerWidth;
@@ -102,6 +107,9 @@
   const keys = {};
   window.addEventListener('keydown', (e) => {
     keys[e.key] = true;
+    if (e.key === 'm') {
+      toggleMenu();
+    }
   });
   window.addEventListener('keyup', (e) => {
     keys[e.key] = false;
@@ -156,12 +164,13 @@
 
     if (keys['Shift']) {
       fov = Math.max(100, fov - 200 * delta);
-      fovInput.value = fov;
     }
     if (keys['Control']) {
       fov = Math.min(800, fov + 200 * delta);
-      fovInput.value = fov;
     }
+
+    fovInput.value = fov;
+    speedInput.value = moveSpeed;
 
     balls.forEach((b) => {
       b.x += b.vx * delta * 60;
@@ -221,8 +230,10 @@
   function animate(time) {
     const delta = (time - last) / 1000;
     last = time;
-    update(delta);
-    draw();
+    if (!paused) {
+      update(delta);
+      draw();
+    }
     requestAnimationFrame(animate);
   }
   requestAnimationFrame(animate);

--- a/pages/index.js
+++ b/pages/index.js
@@ -65,9 +65,14 @@ export default function Home() {
           const fovInput = document.getElementById('menu-fov');
           const speedInput = document.getElementById('menu-speed');
 
-          toggleBtn.addEventListener('click', () => {
+          let paused = false;
+
+          function toggleMenu() {
             menu.classList.toggle('minimized');
-          });
+            paused = !menu.classList.contains('minimized');
+          }
+
+          toggleBtn.addEventListener('click', toggleMenu);
 
           function resize() {
             canvas.width = window.innerWidth;
@@ -107,6 +112,9 @@ export default function Home() {
           const keys = {};
           window.addEventListener('keydown', (e) => {
             keys[e.key] = true;
+            if (e.key === 'm') {
+              toggleMenu();
+            }
           });
           window.addEventListener('keyup', (e) => {
             keys[e.key] = false;
@@ -161,12 +169,13 @@ export default function Home() {
 
             if (keys['Shift']) {
               fov = Math.max(100, fov - 200 * delta);
-              fovInput.value = fov;
             }
             if (keys['Control']) {
               fov = Math.min(800, fov + 200 * delta);
-              fovInput.value = fov;
             }
+
+            fovInput.value = fov;
+            speedInput.value = moveSpeed;
 
             balls.forEach((b) => {
               b.x += b.vx * delta * 60;
@@ -226,8 +235,10 @@ export default function Home() {
           function animate(time) {
             const delta = (time - last) / 1000;
             last = time;
-            update(delta);
-            draw();
+            if (!paused) {
+              update(delta);
+              draw();
+            }
             requestAnimationFrame(animate);
           }
           requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- sync range inputs with internal values so indicators update correctly
- add `m` key to toggle menu and pause/resume the scene
- stop updating the scene when paused

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68508a7d1e1c83249f64607d42ba897b