### PR TITLE
Disable menu toggle via M key

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,9 +107,6 @@
   const keys = {};
   window.addEventListener('keydown', (e) => {
     keys[e.key] = true;
-    if (e.key === 'm') {
-      toggleMenu();
-    }
   });
   window.addEventListener('keyup', (e) => {
     keys[e.key] = false;

--- a/pages/index.js
+++ b/pages/index.js
@@ -112,9 +112,6 @@ export default function Home() {
           const keys = {};
           window.addEventListener('keydown', (e) => {
             keys[e.key] = true;
-            if (e.key === 'm') {
-              toggleMenu();
-            }
           });
           window.addEventListener('keyup', (e) => {
             keys[e.key] = false;


### PR DESCRIPTION
## Summary
- remove `m` key listener for toggling the menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68520584e18c8324b98f4321281cb8f4